### PR TITLE
Adding support for timeout values to be defined in json

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ This tool is still experimental.
      *                  doesn't know when the service has actually started.
      *
      * [stop]           Script that stops this service.
+     *
+     * [timeout.start]  Timeout for the start method (default: 10)
+     *
+     * [timeout.stop]   Timeout for the stop method (default: 30)
      */
 
 
@@ -76,6 +80,6 @@ This tool makes a ton of assumptions about your service:
 * If you specify any additional dependencies (like other services of yours), that means your service should not be started until those other services are online. However, if those services restart, your service will not be restarted.
 * You only intend to have one instance of your service, and it starts off enabled.
 * SMF provides a mechanism for timing out the "start" operation. But for simplicity, this tool always runs your start script in the background, so as far as SMF sees it starts almost instantly. If you want to detect "start" timeout, you must implement a start method that returns exactly when your program has started providing service (e.g., opened its server socket), and you'll have to write your own manifest rather than use this tool.
-* By default, the "stop" method just kills all processes in this service, which includes all processes forked by the initial "start" script. You can override this with a "stop" script, but you should use the default if that script is only going to kill processes. There's a 30 second timeout on the stop script, so the processes must exit within about 30 seconds of receiving the signal.
+* By default, the "stop" method just kills all processes in this service, which includes all processes forked by the initial "start" script. You can override this with a "stop" script, but you should use the default if that script is only going to kill processes. There's a default 30 second timeout on the stop script, so the processes must exit within about 30 seconds of receiving the signal.
 * The service does not use SMF to store configuration properties.
 * The start and stop scripts run as root in a vanilla environment.

--- a/smfgen
+++ b/smfgen
@@ -80,6 +80,8 @@ function emitManifest(stream, conf)
 		fmri = 'application/' + conf['ident'];
 	}
 
+	if (!conf.timeout) conf.timeout = {};
+
 	xml.emitDoctype('service_bundle', 'SYSTEM',
 	    '/usr/share/lib/xml/dtd/service_bundle.dtd.1');
 	xml.emitComment(header_comment);
@@ -115,14 +117,14 @@ function emitManifest(stream, conf)
 		'type': 'method',
 		'name': 'start',
 		'exec': conf['start'] + ' &',
-		'timeout_seconds': 10
+		'timeout_seconds': conf.timeout.start || 10
 	});
 
 	xml.emitEmpty('exec_method', {
 		'type': 'method',
 		'name': 'stop',
 		'exec': stop,
-		'timeout_seconds': 30
+		'timeout_seconds': conf.timeout.stop || 30
 	});
 
 	xml.emitStart('template');


### PR DESCRIPTION
Timeout values can now be given in the json file.
### example

```
dave @ [ bahamas10 :: (Darwin) ] ~/dev/smfgen $ cat hook.json 
{
  "ident": "hook-sms",
  "label": "Hook SMS gateway",
  "start": "/opt/sms/hook-sms.py",
  "timeout": {
    "start": 11,
    "stop": 31
  }
}
dave @ [ bahamas10 :: (Darwin) ] ~/dev/smfgen $ ./smfgen < hook.json 
<?xml version="1.0"?>
<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
<!-- 
    Manifest automatically generated by smfgen.
 -->
<service_bundle type="manifest" name="application-hook-sms" >
    <service name="application/hook-sms" type="service" version="1" >
        <create_default_instance enabled="true" />
        <dependency name="dep0" grouping="require_all" restart_on="error" type="service" >
            <service_fmri value="svc:/milestone/multi-user:default" />
        </dependency>
        <exec_method type="method" name="start" exec="/opt/sms/hook-sms.py &amp;" timeout_seconds="11" />
        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="31" />
        <template >
            <common_name >
                <loctext xml:lang="C" >Hook SMS gateway</loctext>
            </common_name>
        </template>
    </service>
</service_bundle>
```
