### PR TITLE
add basic command line args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -12,5 +12,12 @@
 		"smfgen": "./smfgen"
 	},
 	"license": "MIT",
-	"keywords": [ "illumos", "smartos", "smf" ]
+	"keywords": [
+		"illumos",
+		"smartos",
+		"smf"
+	],
+	"dependencies": {
+		"posix-getopt": "^1.1.0"
+	}
 }

--- a/smfgen
+++ b/smfgen
@@ -330,26 +330,78 @@ XmlEmitter.prototype.emitComment = function (content)
 	this.xe_stream.write('<!-- ' + content + ' -->\n');
 };
 
-function main()
-{
-	var stdin, data, json;
-
-	data = '';
-	stdin = process.openStdin();
-	stdin.setEncoding('utf8');
-	stdin.on('data', function (chunk) { data += chunk; });
-	stdin.on('end', function () {
-		try {
-			json = JSON.parse(data);
-			emitManifest(process.stdout, json);
-		} catch (ex) {
-			console.error('smfgen: ' + ex.message);
-			process.exit(1);
-		}
-	});
+if (require.main !== module) {
+	module.exports = emitManifest;
+  return;
 }
 
-if (require.main === module)
-	main();
-else
-	module.exports = emitManifest;
+// running as a command line tool
+
+if (process.argv.length <= 2) {
+  // no arguments, read stdin
+  var stdin, data, json;
+  data = '';
+  stdin = process.openStdin();
+  stdin.setEncoding('utf8');
+  stdin.on('data', function (chunk) { data += chunk; });
+  stdin.on('end', function () {
+    try {
+      json = JSON.parse(data);
+      emitManifest(process.stdout, json);
+    } catch (ex) {
+      console.error('smfgen: ' + ex.message);
+      process.exit(1);
+    }
+  });
+  return;
+}
+
+function usage() {
+  // TODO
+}
+
+// read arguments, ignore stdin
+var getopt = require('posix-getopt');
+
+var options = [
+  'd:(cwd)',
+  'u:(user)',
+  'g:(group)',
+  'i:(ident)',
+  'l:(label)',
+  'e:(env)',
+  'p:(privilege)',
+  's:(start)',
+  'S:(stop)'
+].join('');
+var parser = new getopt.BasicParser(options, process.argv);
+
+var data = {
+  start: {
+    privileges: [],
+    environment: {}
+  },
+  stop: {}
+};
+var option;
+while ((option = parser.getopt()) !== undefined) {
+  switch (option.option) {
+    case 'd': data.start.working_directory = option.optarg; break;
+    case 'u': data.start.user = option.optarg; break;
+    case 'g': data.start.group = option.optarg; break;
+    case 'i': data.ident = option.optarg; break;
+    case 'l': data.label = option.optarg; break;
+    case 'e':
+      var arg = option.optarg;
+      var eq = arg.indexOf('=');
+      if (eq < 0)
+        break;
+      data.start.environment[arg.substr(0, eq)] = arg.substr(eq + 1);
+      break;
+    case 'p': data.start.privileges.push(option.optarg); break;
+    case 's': data.start.exec = option.optarg; break;
+    case 'S': data.stop.exec = option.optarg; break;
+    default: console.error(usage()); process.exit(1); break;
+  }
+}
+emitManifest(process.stdout, data);


### PR DESCRIPTION
# summary

add command line support to `smfgen`

This is just a proof-of-concept... and is not by any means complete. Let me know what you think about this implementation... it still needs work.

```
$ ./smfgen -i nginx -l 'NGINX Web Server' -s 'nginx -d' -d /var/www -u nobody -g other -p basic -p net_privaddr -eHOME=/var/tmp -ePATH=/bin:/usr/bin
```

``` xml
<?xml version="1.0"?>
<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
<!-- 
    Manifest automatically generated by smfgen.
 -->
<service_bundle type="manifest" name="application-nginx" >
    <service name="application/nginx" type="service" version="1" >
        <create_default_instance enabled="true" />
        <dependency name="dep0" grouping="require_all" restart_on="error" type="service" >
            <service_fmri value="svc:/milestone/multi-user:default" />
        </dependency>
        <exec_method type="method" name="start" exec="nginx -d &amp;" timeout_seconds="10" >
            <method_context working_directory="/var/www" >
                <method_credential user="nobody" group="other" privileges="basic,net_privaddr" />
                <method_environment >
                    <envvar name="HOME" value="/var/tmp" />
                    <envvar name="PATH" value="/bin:/usr/bin" />
                </method_environment>
            </method_context>
        </exec_method>
        <exec_method type="method" name="stop" exec=":kill" timeout_seconds="30" />
        <template >
            <common_name >
                <loctext xml:lang="C" >NGINX Web Server</loctext>
            </common_name>
        </template>
    </service>
</service_bundle>
```
