### PR TITLE
MANTA-4970 smfgen CLI can incorrectly emit empty context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "smfgen",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Generate an SMF manifest from a JSON or CLI description of the service",
 	"author": "Dave Pacheco <dap@joyent.com>",
 	"repository": {

--- a/smfgen
+++ b/smfgen
@@ -452,6 +452,16 @@ function main()
 		}
 	}
 
+	// Remove empty elements
+	Object.keys(data).forEach(function (prop) {
+		var o = data[prop];
+
+		if ((typeof (o) === 'object' && Object.keys(o).length === 0) ||
+		    (Array.isArray(o) && o.length === 0)) {
+			delete data[prop];
+		}
+	});
+
 	try {
 		emitManifest(process.stdout, data);
 	} catch (ex) {


### PR DESCRIPTION
Remove empty elements from the object created during CLI usage.

https://smartos.org/bugview/MANTA-4970